### PR TITLE
Add log rotation script

### DIFF
--- a/scripts/logs/log_rotate.sh
+++ b/scripts/logs/log_rotate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# log_rotate.sh
+# Script to rotate and compress old log files
+
+set -euo pipefail
+
+# Default log directory
+LOG_DIR="/var/log"
+# Number of days to keep logs
+DAYS_TO_KEEP=7
+
+echo "Rotating logs in $LOG_DIR ..."
+echo "Keeping logs modified in the last $DAYS_TO_KEEP days."
+
+# Find and compress old logs
+find "$LOG_DIR" -type f -name "*.log" -mtime +"$DAYS_TO_KEEP" -print -exec gzip {} \;
+
+# Remove very old compressed logs (older than 30 days)
+find "$LOG_DIR" -type f -name "*.log.gz" -mtime +30 -print -delete
+
+echo "Log rotation completed."
+


### PR DESCRIPTION
This PR introduces a new script log_rotate.sh under the logs/ directory.
The script is responsible for rotating and compressing old log files in /var/log, keeping recent logs while archiving older ones. It also deletes compressed logs older than 30 days to free up disk space.